### PR TITLE
libwebkit2gtk-4-1-0 to libwebkit2gtk-4.1-0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Autoware Build GUI is a Tauri / NextJS application designed to simplify the proc
 ## Dependencies
 To run the .deb file directly you will need to first check if these dependencies are installed.
 ```
-sudo apt install libwebkit2gtk-4-1-0 libjavascriptcoregtk-4.1-0 libsoup-3.0-0 libsoup-3.0-common
+sudo apt install libwebkit2gtk-4.1-0 libjavascriptcoregtk-4.1-0 libsoup-3.0-0 libsoup-3.0-common
 ```
 
 To develop the Autoware Build GUI, you'll need to have both Rust and Node.js installed on your system.


### PR DESCRIPTION
Modified typographical errors in dependency commands(libwebkit2gtk-4-1-0 to libwebkit2gtk-4.1-0)
![dash2dot](https://github.com/autowarefoundation/autoware-build-gui/assets/98293904/36ba6dcd-fe04-4803-a723-afac837cacd7)
